### PR TITLE
CD Storefronts

### DIFF
--- a/.github/workflows/test-deploy-storefront.yml
+++ b/.github/workflows/test-deploy-storefront.yml
@@ -1,0 +1,28 @@
+name: Deploy Holaplex Storefront
+
+on:
+  push:
+    branches: [master]
+
+defaults:
+  run:
+    working-directory: js
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '15.x'
+      - run: yarn
+      - run: yarn build
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - run: |
+          aws s3 sync build/web s3://${{ secrets.S3_BUCKET }}/build/web --delete


### PR DESCRIPTION
### Goal

On master merge the storefront app build and is published to s3. The workflow also invalidates the index.html file in the CDN cache so its requested again by users.